### PR TITLE
fix: Prevent NoMethodError on new post creation by forcing site read

### DIFF
--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -22,6 +22,7 @@ module JekyllAdmin
       File.open(path, "wb") do |file|
         file.write(content)
       end
+      JekyllAdmin.site.read
       conditionally_process_site
     end
 


### PR DESCRIPTION
This commit addresses the issue by explicitly calling `JekyllAdmin.site.read` immediately after the file is written in `lib/jekyll-admin/file_helper.rb#write_file`. This forces Jekyll to reload its content and update its internal site index, ensuring the newly created document is properly recognized and accessible.